### PR TITLE
Ci improvements

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,5 @@ matrix:
 #script:
 #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 #  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("NamedTuples"); Pkg.test("NamedTuples"; coverage=true)'
+after_success:
+  - julia -e 'cd(Pkg.dir("NamedTuples")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/README.md
+++ b/README.md
@@ -66,3 +66,5 @@ implementation of these operations is functional rather than performance oriente
 Note the use of `setindex/delete` and not `setindex!/delete!` as these operations do NOT modify in place.
 
 [![Build Status](https://travis-ci.org/blackrock/NamedTuples.jl.svg?branch=master)](https://travis-ci.org/blackrock/NamedTuples.jl)
+[![NamedTuples](http://pkg.julialang.org/badges/NamedTuples_0.6.svg)](http://pkg.julialang.org/?pkg=NamedTuples)
+[![codecov.io](http://codecov.io/github/blackrock/NamedTuples.jl/coverage.svg?branch=master)](http://codecov.io/github/blackrock/NamedTuples.jl?branch=master)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,32 @@
+environment:
+  matrix:
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+
+branches:
+  only:
+    - master
+    - /release-.*/
+
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false
+
+install:
+# Download most recent Julia Windows binary
+  - ps: (new-object net.webclient).DownloadFile(
+        $("http://s3.amazonaws.com/"+$env:JULIAVERSION),
+        "C:\projects\julia-binary.exe")
+# Run installer silently, output to C:\projects\julia
+  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+
+build_script:
+# Need to convert from shallow to complete for Pkg.clone to work
+  - IF EXIST .git\shallow (git fetch --unshallow)
+  - C:\projects\julia\bin\julia -e "versioninfo();
+      Pkg.clone(pwd(), \"NamedTuples\"); Pkg.build(\"NamedTuples\")"
+
+test_script:
+  - C:\projects\julia\bin\julia -e "Pkg.test(\"NamedTuples\")"


### PR DESCRIPTION
Someone with access to the repo here will have to enable both https://www.appveyor.com/ and https://codecov.io/ for this repo. Ideally we would then also add the appveyor badge, but that needs to be added by the person with access to the appveyor account because the URL for that can only be obtained out of the account.

@mdcfrancis 