### PR TITLE
Support for testing on AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,45 @@
+environment:
+  matrix:
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
+  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+
+branches:
+  only:
+    - master
+    - /release-.*/
+
+matrix:
+ allow_failures:
+ - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
+ - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false
+
+install:
+  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
+# If there's a newer build queued for the same PR, cancel this one
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+        throw "There are newer queued builds for this pull request, failing early." }
+# Download most recent Julia Windows binary
+  - ps: (new-object net.webclient).DownloadFile(
+        $env:JULIA_URL,
+        "C:\projects\julia-binary.exe")
+# Run installer silently, output to C:\projects\julia
+  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+
+build_script:
+# Need to convert from shallow to complete for Pkg.clone to work
+  - IF EXIST .git\shallow (git fetch --unshallow)
+  - C:\projects\julia\bin\julia -e "versioninfo();
+      Pkg.clone(pwd(), \"NamedTuples\"); Pkg.build(\"NamedTuples\")"
+
+test_script:
+- C:\projects\julia\bin\julia -e "Pkg.test(\"NamedTuples\")"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/JuliaData/NamedTuples.jl.svg?branch=master)](https://travis-ci.org/JuliaData/NamedTuples.jl)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/JuliaData/NamedTuples.jl?svg=true)](https://ci.appveyor.com/project/quinnj/namedtuples-jl)
 
 # NamedTuples
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Test.bar( @NT( a= 2, c="hello")) # Returns `hellohello`
 There is at most one instance of a NamedTuple type with a given set of Members and Types, hence
 
 ```julia
-typeof( @NT( a::Int64, b::Float64 )(1, 3.0) ) == typeof( @NT( a = 1, b = 2.0 ))
+typeof( @NT( a::Int, b::Float64 )(1, 3.0) ) == typeof( @NT( a = 1, b = 2.0 ))
 ```
 
 NamedTuple definitions are shared across all modules. The underlying immutable types are constructed at first use.

--- a/src/NamedTuples.jl
+++ b/src/NamedTuples.jl
@@ -50,7 +50,7 @@ import Base: ==
 end
 
 # Deep hash
-@generated function Base.hash(nt::NamedTuple, hs::UInt64)
+@generated function Base.hash(nt::NamedTuple, hs::UInt)
     q = quote
         h = 17
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,7 +28,7 @@ using Base.Test
 
 @test @NT(a::Int, b) == @NT(a::Int, b::Any)
 
-@test typeof( @NT( a::Int64, b::Float64 )(1, 3.0) ) == typeof( @NT( a = 1, b = 2.0 ))
+@test typeof( @NT( a::Int, b::Float64 )(1, 3.0) ) == typeof( @NT( a = 1, b = 2.0 ))
 
 # Syntax tests, including anon named tuples
 @test @NT( a, b ) <: NamedTuple


### PR DESCRIPTION
Adds the AppVeyor CI configuration file (from #52) and addresses an issue with `hash` which affecting 32-bit systems.