### PR TITLE
Fix == method

### DIFF
--- a/src/NamedTuples.jl
+++ b/src/NamedTuples.jl
@@ -39,7 +39,7 @@ Base.get( t::NamedTuple, i::Symbol, default ) = i in keys(t) ? t[i] : default
 import Base: ==
 
 @generated function ==( lhs::NamedTuple, rhs::NamedTuple)
-    if !isequal(fieldnames(lhs), fieldnames(rhs)) || lhs !== rhs
+    if !isequal(fieldnames(lhs), fieldnames(rhs))
         return false
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,7 @@ using Base.Test
 @test ( x = @NT( a::Int64, b::Float64 )( 1, 2.0 ) ; typeof(x.a) == Int64 && typeof(x.b) == Float64 )
 @test @NT( a = 1, b = "hello")  ==  @NT( a, b )( 1, "hello")
 @test @NT( a = 1) != @NT( b = 1 )
+@test @NT(a=1) == @NT(a=1.)
 
 @test hash( @NT( a = 1, b = "hello"))  ==  hash( @NT( a, b )( 1, "hello") )
 @test hash( @NT( a = 1, b = "hello")) != hash( @NT( a = 1, b = 2.0 ))


### PR DESCRIPTION
Two named tuples might have fields of different types that hold the same value (say 3 and 3.), in that case we want the comparison to return true.

This essentially restores the v4.0.0 behavior, this incorrect comparison was only added in v4.0.1.

It would be great if we could do a quick bugfix release v4.0.2 that has just this fix in it, this bug is breaking things left and right on my end.

Before we merge this, we should agree what v4.0.2 includes. In particular, I think we should first revert #61 on master, then merge this here, then release v4.0.2, and then figure out what to do about precompilation.