### PR TITLE
Fix allow_failure travis syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ julia:
 notifications:
   email: false
 matrix:
-  allow_failure:
-    - julia: nightly
+  allow_failures:
+  - julia: nightly
 # uncomment the following lines to override the default test script
 #script:
 #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi


### PR DESCRIPTION
I'm not sure why the travis badge shows an error when the julia 0.7 builds break. Maybe this will fix it? I'm not sure...