### PR TITLE
setindex updates existing elements of NT

### DIFF
--- a/src/NamedTuples.jl
+++ b/src/NamedTuples.jl
@@ -320,7 +320,7 @@ This copies the underlying data.
 """ ->
 function setindex{V}( t::NamedTuple, key::Symbol, val::V)
     nt = create_namedtuple_type( [key] )( val )
-    return merge( t, nt )
+    return merge( nt, t )
 end
 
 @doc doc"""

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,6 +57,11 @@ x = setindex( nt, :x, 123 )
 @test x.c == 3
 @test nt[[:c,:b]] == @NT( c=3, b=2 )
 
+
+# Test "in-place" updating of elements
+ntupdate = setindex(nt, :a, 2)
+@test ntupdate.a == 2
+
 y = delete( x, :a)
 @test x != y
 @test haskey( nt, :a ) == true


### PR DESCRIPTION
Fixes `setindex` so that function can "update" arguments in place and added test.  Looks like was an issue with the order of the arguments in `merge` function.

MWE shows current issue
```julia
using NamedTuples
x = @NT(a = 1)
@show setindex(x, :a, 2) # (a=1)
@show merge(@NT(a=2), x) # (a=2) CORRECT!
@show merge(x, @NT(a=2)) # (a=1)
```