### PR TITLE
Convert `fields` to array before passing into `create_namedtuple_type`

### DIFF
--- a/src/NamedTuples.jl
+++ b/src/NamedTuples.jl
@@ -271,7 +271,7 @@ end
     M = length(nts)
 
     # This type will already exist if this function may be called
-    NT = create_namedtuple_type(fields, moduleof(nts[1]))
+    NT = create_namedtuple_type(collect(fields), moduleof(nts[1]))
     args = Expr[:(f($(Expr[:(getfield(nts[$i], $j)) for i = 1:M]...))) for j = 1:N]
     quote
         $NT($(args...))


### PR DESCRIPTION
Fixes this error
```julia
ERROR: MethodError: no method matching create_namedtuple_type(::Tuple{Symbol}, ::Module)
Closest candidates are:
  create_namedtuple_type(::Array{Symbol,1}, ::Module) at /home/scheme/.julia/packages/NamedTuples/soFSo/src/NamedTuples.jl:164
Stacktrace:
 [1] #s21#20 at /home/scheme/.julia/packages/NamedTuples/soFSo/src/NamedTuples.jl:274 [inlined]
 [2] #s21#20(::Any, ::Any, ::Any) at ./none:0
```